### PR TITLE
Disable desktop options for wlroots compositors.

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3450,6 +3450,7 @@ void GuiMenu::openUISettings()
 			SystemConf::getInstance()->saveSystemConf();
 		});
 
+#ifndef _WLROOTS
 	auto desktop_enabled = std::make_shared<SwitchComponent>(mWindow);
 	bool desktopEnabled = SystemConf::getInstance()->get("desktop.enabled") == "1";
 	desktop_enabled->setState(desktopEnabled);
@@ -3467,7 +3468,7 @@ void GuiMenu::openUISettings()
 			}, "NO",nullptr));
 		}
 	});
-
+#endif
 
 	s->addGroup(_("DISPLAY OPTIONS"));
 


### PR DESCRIPTION
Foot segfault when launched from the desktop.