### PR TITLE
add gpu driver option for panfrost/libmali switch

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1243,6 +1243,30 @@ void GuiMenu::openSystemSettings_batocera()
                 });
         }
 
+        const std::string gpuDriverScript = "/usr/bin/gpudriver";
+        if (Utils::FileSystem::exists(gpuDriverScript)) {
+                auto optionsGpuDriver = std::make_shared<OptionListComponent<std::string> >(mWindow, _("GPU DRIVER"), false);
+                std::string selectedGpuDriver = std::string(getShOutput(R"(/usr/bin/gpudriver)"));
+
+                std::string a;
+                for(std::stringstream ss(getShOutput(R"(/usr/bin/gpudriver --options)")); getline(ss, a, ' '); ) {
+                        optionsGpuDriver->add(a, a, a == selectedGpuDriver);
+                }
+
+                s->addWithLabel(_("GPU DRIVER"), optionsGpuDriver);
+
+                s->addSaveFunc([this, window, gpuDriverScript, optionsGpuDriver, selectedGpuDriver] {
+                        if (optionsGpuDriver->changed()) {
+                                runSystemCommand(gpuDriverScript + " " + optionsGpuDriver->getSelected(), "", nullptr);
+                                window->pushGui(new GuiMsgBox(window, _("GPU driver will be switched on next reboot"),
+                                            _("Reboot now"), [] { quitES(QuitMode::REBOOT); },
+                                            _("later"), nullptr)
+                                        );
+                        }
+                });
+        }
+
+
 	s->addGroup(_("HARDWARE / POWER SAVING"));
         // Automatically enable or disable enhanced power saving mode
         auto enh_powersave = std::make_shared<SwitchComponent>(mWindow);


### PR DESCRIPTION
# Add `GPU DRIVER` option to system settings

## Description

When the corresponding script exists:
  * query the script for current and available GPU drivers
  * add an option list
  * upon change call the script to select the new driver
  * suggest reboot

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested Locally?

- [x] Fresh install with libmali, there is an option list, "panfrost" is selected by default
- [x] Select "libmali", agree to reboot, `lsmod` shows `mali_kbase`
- [x] Select "panfrost", agree to reboot, `lsmod` shows `panfrost`

**Test Configuration**:
* Build OS name and version: Ubuntu 22.04
* Docker (Y/N): Y
* ROCKNIX Branch: stolen/rk3566-libmali-2
* Any additional information that may be useful: 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

