### PR TITLE
ES: add new GUI element to control Stereo/Mono playback

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3779,7 +3779,25 @@ void GuiMenu::openSoundSettings()
 	s->addWithLabel(_("ENABLE VIDEO PREVIEW AUDIO"), video_audio);
 	s->addSaveFunc([video_audio] { Settings::getInstance()->setBool("VideoAudio", video_audio->getState()); });
 
+    const std::string audioVDriverScript = "/usr/bin/audio_vdriver.sh";
+    if (Utils::FileSystem::exists(audioVDriverScript)) {
+        auto optionsVAudioDriver = std::make_shared<OptionListComponent<std::string> >(mWindow, _("AUDIO PLAYBACK DRIVER"), false);
+		std::string selectedVAudioDriver = std::string(getShOutput(R"(/usr/bin/audio_vdriver.sh)"));
 
+        std::string a;
+        for(std::stringstream ss(getShOutput(R"(/usr/bin/audio_vdriver.sh --options)")); getline(ss, a, ' '); ) {
+                optionsVAudioDriver->add(a, a, a == selectedVAudioDriver);
+        }
+
+        s->addWithLabel(_("AUDIO PLAYBACK DRIVER"), optionsVAudioDriver);
+
+       Window *window = mWindow;
+       s->addSaveFunc([this, window, audioVDriverScript, optionsVAudioDriver, selectedVAudioDriver] {
+        if (optionsVAudioDriver->changed()) {
+            runSystemCommand(audioVDriverScript + " " + optionsVAudioDriver->getSelected(), "", nullptr);
+            }
+        });
+    }
 
 	mWindow->pushGui(s);
 }


### PR DESCRIPTION
for SX20 or other mono speaker devices, allow user to switch between stereo and mono for better experience audio experience.  This PR MUST go with the corresponding PR on the distribution side.

Fixes # (issue)

mono speaker not getting audio from left channel from emulators

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

Tested with PowKiddy SX20, PowKiddy RGB30 and PowKiddy X55

**Test Configuration**:
* Build OS: latest dev pull
* Docker (Y/N): N
* ROCKNIX Branch: latest dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
