### PR TITLE
main: refactor the main rendering loop to allow better screen off power

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -524,6 +524,7 @@ int main(int argc, char* argv[])
 
 	int lastTime = SDL_GetTicks();
 	int ps_time = SDL_GetTicks();
+	int frameStart_time;
 
 	delete stopWatch;
 
@@ -534,41 +535,31 @@ int main(int argc, char* argv[])
 
 		SDL_Event event;
 
-		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
-		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
+		/* grab inital timestamp */
+		frameStart_time = SDL_GetTicks();
+
+		/* if in sleep, it will come back here over and over again, so 1ms delay is fine */
+		if(window.isSleeping())
 		{
+			lastTime = SDL_GetTicks();
+
 			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
 			// Reset this event's state
 			TRYCATCH("resetRefreshEvent", PowerSaver::resetRefreshEvent());
 
-			do
-			{
-				TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
+			/* it's sleeping so don't disturb for a while */
+			SDL_Delay(30);
 
-				if (event.type == SDL_QUIT)
-					running = false;
-			} 
-			while(SDL_PollEvent(&event));
+			/* wait for event or timeout */
+			SDL_WaitEventTimeout(&event, 3);
 
-			// triggered if exiting from SDL_WaitEvent due to event
-			if (ps_standby)
-				// show as if continuing from last event
-				lastTime = SDL_GetTicks();
+			/* parse event */
+			TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
 
-			// reset counter
-			ps_time = SDL_GetTicks();
-		}
-		else if (ps_standby)
-		{
-			// If exitting SDL_WaitEventTimeout due to timeout. Trail considering
-			// timeout as an event
-		//	ps_time = SDL_GetTicks();
-		}
+			if (event.type == SDL_QUIT)
+				running = false;
 
-		if(window.isSleeping())
-		{
-			lastTime = SDL_GetTicks();
-			SDL_Delay(1); // this doesn't need to be accurate, we're just giving up our CPU time until something wakes us up
+			// bypassing all updates and rendering
 			continue;
 		}
 
@@ -576,17 +567,39 @@ int main(int argc, char* argv[])
 		int deltaTime = curTime - lastTime;
 		lastTime = curTime;
 
-		// cap deltaTime if it ever goes negative
+		// cap deltaTime if it ever goes negative, set it 1 second instead
 		if(deltaTime < 0)
 			deltaTime = 1000;
 
+		/* update and render */
 		TRYCATCH("Window.update" ,window.update(deltaTime))	
 		TRYCATCH("Window.render", window.render())
-
 		Renderer::swapBuffers();
 
+		/* and flush out all outstanding log buffers */
 		Log::flush();
-	}
+
+		/* calculate time remaing based on 30 Hz (33.3 ms)*/
+		curTime = SDL_GetTicks();
+		deltaTime = curTime - frameStart_time;
+
+		/* try to run at around 30 Hz, if nothing happens */
+		if (deltaTime < 30 && deltaTime >= 1)
+		{
+			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
+			// Reset this event's state
+			TRYCATCH("resetRefreshEvent", PowerSaver::resetRefreshEvent());
+
+			/* wait for event or timeout */
+			SDL_WaitEventTimeout(&event, deltaTime);
+
+			/* parse event */
+			TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
+
+			if (event.type == SDL_QUIT)
+				running = false;
+		}
+	} /* while (running) */
 
 	if (isFastShutdown())
 		Settings::getInstance()->setBool("IgnoreGamelist", true);


### PR DESCRIPTION
usage and reduce screen on rendering to be around 30Hz and event driven

this saves around 25% power drain while screen is off and around 5% power drain while screen is on

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A - test before refactoring and measure battery drain via current_avg from battery device
- [x] Test B - test after refactoring and collect the same data and compute the delta

**Test Configuration**:
* Build OS name and version: Latest Dev Pull
* Docker (Y/N): N
* Rocknix Branch: dev
* Any additional information that may be useful:
This change is a first step to reduce ES idle drain.  Recommended usage, set screensaver to black screen and set timeout to 1 min to maximize the savings from this update.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

