### PR TITLE
Fix idle battery drain issue

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -180,9 +180,12 @@ void SystemScreenSaver::startScreenSaver()
 		}	
 	}
 
-	// No videos. Just use a standard screensaver
+	// No videos. Just use a standard screensaver (black screen)
 	mState = STATE_SCREENSAVER_ACTIVE;
 	mCurrentGame = NULL;
+	if (AudioManager::isInitialized())
+		AudioManager::getInstance()->deinit();
+
 }
 
 void SystemScreenSaver::stopScreenSaver()
@@ -226,6 +229,10 @@ void SystemScreenSaver::stopScreenSaver()
 				AudioManager::getInstance()->playRandomMusic();
 		}
 	}
+
+	/* coming out of black screensaver */
+	if (!AudioManager::isInitialized())
+		AudioManager::getInstance()->init();
 }
 
 void SystemScreenSaver::renderScreenSaver()


### PR DESCRIPTION
# Pull Request Template

## Description

refactor the main rendering loop to allow better screen off power
usage and reduce screen on rendering to be around 30Hz and event driven

if no input events are happening, then the rendering loop will render
around 30Hz, if input events are queued, it will render just as before
(which is limited by vsync at 60Hz)

this saves around 25% power drain while screen is off and around 5-8%
power drain while screen is on

Fix audio stream being held during blank screensaver
the audio streams are constantly being consumed and active thus leading
to 10-25% additional CPU resources consumed.  Release AudioManager when
blank screen is active to let those audiostreams go into idle/suspend so the
system can go into proper idle.  This saves another 20-25% battery drain during
screensaver event.

Fixes # (issue)
Fix Battery drain during idle with screen on or off.
Screen on saves around 5-8% battery drain compared to baseline
screen off saves around 40-50% battery drain compared to baseline

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested Locally?

- [x] Test A - load existing pre-patched release, measure the current drain from /sys/class/power_supply/current_avg and note the current drain amount
- [x] Test B - load post patched release, measure the same drain and note the current drain amount

Tested on multiple RK3566 devices such as RGB30, RGB20SX and X55

**Test Configuration**:
* Build OS name and version: Rocknix
* Rocknix Branch: Dev

* Any additional information that may be useful:
Please pull this will corresponding changes on the CPU governor PR for additional 1~2% savings

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

