### PR TITLE
ES: main: refactored rendering loop to be more energy efficient

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -524,6 +524,7 @@ int main(int argc, char* argv[])
 
 	int lastTime = SDL_GetTicks();
 	int ps_time = SDL_GetTicks();
+	int frameStart_time;
 
 	delete stopWatch;
 
@@ -531,44 +532,33 @@ int main(int argc, char* argv[])
 
 	while(running)
 	{
-
 		SDL_Event event;
 
-		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
-		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
+		/* grab inital timestamp */
+		frameStart_time = SDL_GetTicks();
+
+		/* if in sleep, it will come back here over and over again, so 25ms delay is fine */
+		if(window.isSleeping())
 		{
+			lastTime = SDL_GetTicks();
+
 			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
 			// Reset this event's state
 			TRYCATCH("resetRefreshEvent", PowerSaver::resetRefreshEvent());
 
-			do
-			{
-				TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
+			/* it's sleeping so don't disturb for a while */
+			SDL_Delay(22);
 
-				if (event.type == SDL_QUIT)
-					running = false;
-			} 
-			while(SDL_PollEvent(&event));
+			/* wait for event or timeout */
+			SDL_WaitEventTimeout(&event, 3);
 
-			// triggered if exiting from SDL_WaitEvent due to event
-			if (ps_standby)
-				// show as if continuing from last event
-				lastTime = SDL_GetTicks();
+			/* parse event */
+			TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
 
-			// reset counter
-			ps_time = SDL_GetTicks();
-		}
-		else if (ps_standby)
-		{
-			// If exitting SDL_WaitEventTimeout due to timeout. Trail considering
-			// timeout as an event
-		//	ps_time = SDL_GetTicks();
-		}
+			if (event.type == SDL_QUIT)
+				running = false;
 
-		if(window.isSleeping())
-		{
-			lastTime = SDL_GetTicks();
-			SDL_Delay(1); // this doesn't need to be accurate, we're just giving up our CPU time until something wakes us up
+			// bypassing all updates and rendering
 			continue;
 		}
 
@@ -576,17 +566,40 @@ int main(int argc, char* argv[])
 		int deltaTime = curTime - lastTime;
 		lastTime = curTime;
 
-		// cap deltaTime if it ever goes negative
+		// cap deltaTime if it ever goes negative, set it 1 second instead
 		if(deltaTime < 0)
 			deltaTime = 1000;
 
+		/* update and render */
 		TRYCATCH("Window.update" ,window.update(deltaTime))	
 		TRYCATCH("Window.render", window.render())
-
 		Renderer::swapBuffers();
 
+		/* and flush out all outstanding log buffers */
 		Log::flush();
-	}
+
+		/* calculate time remaing based on 40 Hz (25 ms)*/
+		curTime = SDL_GetTicks();
+		deltaTime = curTime - frameStart_time;
+
+		/* try to run at around 40 Hz, if nothing happens */
+		if (deltaTime < 25 && deltaTime >= 1)
+		{
+
+			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
+			// Reset this event's state
+			TRYCATCH("resetRefreshEvent", PowerSaver::resetRefreshEvent());
+
+			/* wait for event or timeout */
+			SDL_WaitEventTimeout(&event, deltaTime);
+
+			/* parse event */
+			TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
+
+			if (event.type == SDL_QUIT)
+				running = false;
+		}
+	} /* while (running) MAIN RENDERING LOOP */
 
 	if (isFastShutdown())
 		Settings::getInstance()->setBool("IgnoreGamelist", true);


### PR DESCRIPTION
## Description
if no input events are happening, then the rendering loop will render
around 40Hz, if input events are queued, it will render just as before
(which is limited by vsync at 60Hz)

this saves around 25% power drain while screen is off and around 5-8%
power drain while screen is on

Fixes # (issue)

if no input events are happening, then the rendering loop will render
around 40Hz, if input events are queued, it will render just as before
(which is limited by vsync at 60Hz)

this saves around 25% power drain while screen is off and around 5-8%
power drain while screen is on

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested Locally?

- [x] Test A - load existing pre-patched release, measure the current drain from /sys/class/power_supply/current_avg and note the current drain amount
- [x] Test B - load post patched release, measure the same drain and note the current drain amount

**Test Configuration**:
* Build OS name and version: latest dev
* Docker (Y/N): N
* Rocknix Branch: dev

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
