### PR TITLE
Moonlight - add build var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(ENABLE_TTS "Set to ON to enable text to speech" OFF)
 option(ENABLE_UPDATES "Set to ON to enable online updates." ${ENABLE_UPDATES})
 option(PANFROST "Set to 1 to enable panfrost settings." ${PANFROST})
 option(WLROOTS "Set to 1 to enable wlroots settings." ${WLROOTS})
+option(MOONLIGHT "Set to 1 to enable moonlight settings." ${MOONLIGHT})
 
 # emuelec
 option(ENABLE_EMUELEC "Set to ON to enable EmuELEC changes" ${ENABLE_EMUELEC})
@@ -50,6 +51,10 @@ endif()
 
 if("${WLROOTS}" STREQUAL "1")
     add_definitions(-D_WLROOTS)
+endif()
+
+if("${MOONLIGHT}" STREQUAL "1")
+    add_definitions(-D_MOONLIGHT)
 endif()
 
 # emuelec

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -140,7 +140,7 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 
 		if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::WIFI)) {
 			addEntry(_("NETWORK SETTINGS").c_str(), true, [this] { openNetworkSettings_batocera(); }, "iconNetwork");
-#if defined(AMD64) || defined(RK3326) || defined(RK3566) || defined(RK3566_X55) || defined(RK3588) || defined(RK3399)
+#ifdef _MOONLIGHT
 		  addEntry(_("MOONLIGHT GAME STREAMING").c_str(), true, [this] { GuiMoonlight::show(mWindow); }, "iconGames");
 #endif
 		}


### PR DESCRIPTION
Currently the 'MOONLIGHT GAME STREAMING' settings menu is controlled by inspecting the build platform.

This change introduces a `MOONLIGHT` build var, with values 0 to hide the menu and 1 to show the menu.