### PR TITLE
Add suspend and shutdown options to screensaver

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -23,6 +23,7 @@
 #include "BrightnessControl.h"
 #include "ImageIO.h"
 #include "utils/Randomizer.h"
+#include "platform.h"
 
 #define FADE_TIME 			500
 
@@ -183,6 +184,15 @@ void SystemScreenSaver::startScreenSaver()
 	// No videos. Just use a standard screensaver
 	mState = STATE_SCREENSAVER_ACTIVE;
 	mCurrentGame = NULL;
+
+        if (screensaver_behavior == "suspend")
+        {
+            runSystemCommand("/usr/bin/systemctl suspend", "", nullptr);
+        }
+        else if (screensaver_behavior == "shutdown")
+        {
+            runSystemCommand("/usr/bin/systemctl poweroff", "", nullptr);
+        }
 }
 
 void SystemScreenSaver::stopScreenSaver()

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -42,7 +42,7 @@ GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, int s
 	
 	// Screensaver behavior
 	auto ctlBehavior = std::make_shared< OptionListComponent<std::string> >(mWindow, _("SCREENSAVER TYPE"), false);
-	ctlBehavior->addRange({ "dim", "black", "random video", "slideshow" }, ssBehavior);
+	ctlBehavior->addRange({ "dim", "black", "random video", "slideshow", "suspend", "shutdown" }, ssBehavior);
 	addWithLabel(_("SCREENSAVER TYPE"), ctlBehavior, selectItem == 1);
 	ctlBehavior->setSelectedChangedCallback([this](const std::string& name)
 	{


### PR DESCRIPTION
This adds `SUSPEND` and `SHUTDOWN` as options to the screensaver. I put the options under screensaver to avoid confusion about the timeouts (e.g. if you have the device set to shutdown after 2m but screensaver after 5m, should the timeout for shutdown occur before the screensaver or does the shutdown timeout wait until the screensaver has started?). I've attached screenshots for reference as well, taken from my RGB30.

![rocknix-suspend](https://github.com/user-attachments/assets/c8b08948-ace2-40e2-8273-f7621f4e4046)

![rocknix-shutdown](https://github.com/user-attachments/assets/748c517b-ddfc-4a67-a9d6-1e100c73b50e)

Of note is that the behavior only affects emulationstation, so the device still won't suspend or sleep while a game is open. I have a WIP branch[^1] where I've added `swayidle` as a package to attempt to get the device to suspend mid-game after some inactivity, but it seems that XWayland and/or the emulators don't properly support idle-inhibit[^2], so in my testing my device would just suspend or shutdown in the middle of gameplay despite actively playing.

[^1]: https://github.com/wbrawner/distribution/tree/idle-suspend
[^2]: https://github.com/swaywm/swayidle/issues/5