### PR TITLE
Exclude ports dirs from scanning thanks @christianhaitian

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -269,7 +269,7 @@ void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::stri
 			}
 
 			// Don't loose time looking in downloaded_images, downloaded_videos & media folders
-			if (fn == "media" || fn == "medias" || fn == "images" || fn == "manuals" || fn == "videos" || fn == "assets" || Utils::String::startsWith(fn, "downloaded_") || Utils::String::startsWith(fn, "."))
+			if (fn == "media" || fn == "medias" || fn == "images" || fn == "manuals" || fn == "videos" || fn == "assets" || Utils::String::startsWith(fn, "downloaded_") || Utils::String::startsWith(fn, ".") || fileInfo.path.rfind("/ports") != std::string::npos)
 				continue;
 
 			// Hardcoded optimisation : WiiU has so many files in content & meta directories


### PR DESCRIPTION
There is a degradation in exfat performance in 6.10+ kernels, reason unknown. But ES can take forever scanning exfat cards with many files, excluding ports subdirs works around this and is anyway not a bad thing to do.

