### PR TITLE
Use Google captive portal server for network connectivity checking

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -279,7 +279,7 @@ std::pair<std::string, int> ApiSystem::scrape(BusyComponent* ui)
 
 bool ApiSystem::ping() 
 {
-	if (!executeScriptLegacy("timeout 1 ping -c 1 -t 255 -w 1 8.8.8.8")) // ping Google DNS
+	if (!executeScriptLegacy("timeout 3 curl http://www.google.com/generate_204")) // Google's connectivity check on Android
 		return executeScriptLegacy("timeout 2 ping -c 1 -t 255 -w 1 8.8.4.4"); // ping Google secondary DNS & give 2 seconds
 
 	return true;


### PR DESCRIPTION
This PR replaces the use of `ping` for network connectivity checks with the method used on Android and iOS.

Using `ping` sends ICMP packets, which works well under a VPN but can cause issues with (transparent) proxies that only support TCP/HTTP traffic. For users who rely on proxy servers to improve download speeds for themes or OTA updates, a failed ping test could block them from downloading updates, even if they can still access GitHub over HTTP.